### PR TITLE
Unify period classification into pitedgar.periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-12
+
+### Fixed
+- **Period classification inconsistency between parser and query**: the parser used 60–100 days for "quarterly" during within-filing dedup while the query layer used 60–105 days for Q4 derivation, TTM, and snapshot selection. Companies with ~101–105 day quarters (e.g. JNJ Q4) could be misclassified during dedup. Both layers now share a single source of truth in the new `pitedgar.periods` module (60–105 days).
+
+### Changed
+- **New `pitedgar.periods` module**: centralizes day-count thresholds (`Q_MIN`/`Q_MAX`/`A_MIN`/`A_MAX`) and exposes `is_quarterly` / `is_annual` boolean masks. Internal refactor; no public API changes.
+
 ## [0.2.2] - 2026-04-12
 
 ### Fixed

--- a/pitedgar/parser.py
+++ b/pitedgar/parser.py
@@ -8,6 +8,7 @@ from loguru import logger
 from tqdm import tqdm
 
 from pitedgar.config import PitEdgarConfig, CONCEPT_ALIASES
+from pitedgar.periods import is_quarterly
 
 # Units to attempt per concept, in priority order.
 # EPS and share concepts use "shares"; everything else USD.
@@ -128,9 +129,9 @@ def parse_company(
     df["duration_days"] = (df["end"] - df["start"]).dt.days.where(df["start"].notna(), -1)
 
     # Within-filing dedup: a single filing can contain both a discrete quarter and a YTD
-    # cumulative entry for the same (concept, end). Prefer the discrete quarter (60-100 days).
+    # cumulative entry for the same (concept, end). Prefer the discrete quarter.
     # We dedup on (concept, end, filed) so restatements filed on different dates are preserved.
-    df["_is_quarterly"] = ((df["duration_days"] >= 60) & (df["duration_days"] <= 100)).astype(int)
+    df["_is_quarterly"] = is_quarterly(df["duration_days"]).astype(int)
     df = (
         df.sort_values(["filed", "_is_quarterly"])
         .drop_duplicates(subset=["concept", "end", "filed"], keep="last")

--- a/pitedgar/periods.py
+++ b/pitedgar/periods.py
@@ -1,0 +1,33 @@
+"""Period classification for SEC filing durations.
+
+Single source of truth for the day-count thresholds that distinguish
+quarterly from annual periods. Both the parser (within-filing dedup)
+and the query layer (Q4 derivation, TTM, snapshots) classify periods
+using these bounds.
+
+Quarterly: 60-105 days covers standard 3-month periods including
+fiscal-calendar quirks (e.g. JNJ Q4 spans Oct-Jan = ~97 days).
+Annual: 340-380 days covers 12-month fiscal years including 52/53-week
+calendars.
+"""
+
+import pandas as pd
+
+Q_MIN, Q_MAX = 60, 105
+A_MIN, A_MAX = 340, 380
+
+
+def is_quarterly(duration_days: pd.Series) -> pd.Series:
+    """Boolean mask: True where duration_days falls in the quarterly range."""
+    return (duration_days >= Q_MIN) & (duration_days <= Q_MAX)
+
+
+def is_annual(duration_days: pd.Series, form: pd.Series | None = None) -> pd.Series:
+    """Boolean mask: True where duration_days falls in the annual range.
+
+    If `form` is provided, additionally requires form == "10-K".
+    """
+    mask = (duration_days >= A_MIN) & (duration_days <= A_MAX)
+    if form is not None:
+        mask = mask & (form == "10-K")
+    return mask

--- a/pitedgar/query.py
+++ b/pitedgar/query.py
@@ -4,33 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
-# Duration thresholds for period classification.
-# Quarterly: 60–105 days covers standard 3-month periods including fiscal-calendar
-# quirks (e.g. JNJ Q4 spans Oct–Jan = 97 days).
-# Annual: 340–380 days covers 12-month fiscal years including 52/53-week calendars.
-_Q_DURATION_MIN = 60
-_Q_DURATION_MAX = 105
-_A_DURATION_MIN = 340
-_A_DURATION_MAX = 380
-
-
-def _is_quarterly(df: pd.DataFrame) -> "pd.Series[bool]":
-    """True for rows that represent a discrete quarterly period (60–105 days).
-
-    Works regardless of the filing form — quarterly periods sometimes appear in
-    10-K filings as comparative data (e.g. JNJ, which reports discrete quarters
-    only inside annual 10-K filings in EDGAR).
-    """
-    return (df["duration_days"] >= _Q_DURATION_MIN) & (df["duration_days"] <= _Q_DURATION_MAX)
-
-
-def _is_annual_10k(df: pd.DataFrame) -> "pd.Series[bool]":
-    """True for rows that represent a full-year period from a 10-K filing (340–380 days)."""
-    return (
-        (df["form"] == "10-K")
-        & (df["duration_days"] >= _A_DURATION_MIN)
-        & (df["duration_days"] <= _A_DURATION_MAX)
-    )
+from pitedgar.periods import is_annual, is_quarterly
 
 
 def _snapshot_events(grp: pd.DataFrame) -> pd.DataFrame:
@@ -305,8 +279,12 @@ class PitQuery:
         # Use duration_days to identify quarterly periods (60–105 days), regardless
         # of form. Some companies (e.g. JNJ) report discrete quarterly values only
         # inside 10-K filings as comparative data; form='10-Q' would miss them.
-        sub = self.data.loc[base_mask & _is_quarterly(self.data)].sort_values("filed")
-        sub_k = self.data.loc[base_mask & _is_annual_10k(self.data)]
+        sub = self.data.loc[
+            base_mask & is_quarterly(self.data["duration_days"])
+        ].sort_values("filed")
+        sub_k = self.data.loc[
+            base_mask & is_annual(self.data["duration_days"], self.data["form"])
+        ]
 
         if sub.empty:
             return pd.DataFrame(columns=["ticker", "concept", "filed", "ttm_val", "n_periods"])
@@ -383,8 +361,12 @@ class PitQuery:
         concept_mask = self.data["concept"] == concept
         if tickers is not None:
             concept_mask &= self.data["ticker"].isin(universe)
-        df_q = self.data.loc[concept_mask & _is_quarterly(self.data)].sort_values(["ticker", "filed"])
-        df_k = self.data.loc[concept_mask & _is_annual_10k(self.data)]
+        df_q = self.data.loc[
+            concept_mask & is_quarterly(self.data["duration_days"])
+        ].sort_values(["ticker", "filed"])
+        df_k = self.data.loc[
+            concept_mask & is_annual(self.data["duration_days"], self.data["form"])
+        ]
 
         # Group 10-K rows by ticker for O(1) lookup inside the per-ticker loop.
         k_by_ticker = {t: g for t, g in df_k.groupby("ticker", sort=False)} if not df_k.empty else {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pitedgar"
-version = "0.2.2"
+version = "0.2.3"
 description = "Point-in-time SEC EDGAR financial data pipeline"
 authors = ["Ariel Nacamulli"]
 license = "MIT"

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -1,0 +1,40 @@
+"""Boundary tests for pitedgar.periods."""
+
+import pandas as pd
+
+from pitedgar.periods import A_MAX, A_MIN, Q_MAX, Q_MIN, is_annual, is_quarterly
+
+
+def test_is_quarterly_inclusive_bounds():
+    s = pd.Series([Q_MIN - 1, Q_MIN, 91, Q_MAX, Q_MAX + 1])
+    result = is_quarterly(s).tolist()
+    assert result == [False, True, True, True, False]
+
+
+def test_is_quarterly_handles_negative_and_zero():
+    s = pd.Series([-1, 0, 30])
+    assert is_quarterly(s).tolist() == [False, False, False]
+
+
+def test_is_annual_inclusive_bounds_no_form():
+    s = pd.Series([A_MIN - 1, A_MIN, 365, A_MAX, A_MAX + 1])
+    result = is_annual(s).tolist()
+    assert result == [False, True, True, True, False]
+
+
+def test_is_annual_with_form_requires_10k():
+    duration = pd.Series([365, 365, 365])
+    form = pd.Series(["10-K", "10-Q", "10-K/A"])
+    assert is_annual(duration, form).tolist() == [True, False, False]
+
+
+def test_is_annual_with_form_still_checks_duration():
+    duration = pd.Series([100, 365, 400])
+    form = pd.Series(["10-K", "10-K", "10-K"])
+    assert is_annual(duration, form).tolist() == [False, True, False]
+
+
+def test_jnj_q4_at_upper_quarterly_bound():
+    """Regression: JNJ Q4 spans ~97-105 days. Must classify as quarterly."""
+    s = pd.Series([97, 101, 105])
+    assert is_quarterly(s).all()


### PR DESCRIPTION
## Summary

- New `pitedgar/periods.py` module owns the quarterly (60-105d) and annual (340-380d) day-count thresholds
- `parser.py` and `query.py` now import `is_quarterly` / `is_annual` instead of inlining their own thresholds
- Fixes a latent inconsistency: parser previously used 60-100d for quarterly while query used 60-105d, which could misclassify ~101-105 day quarters (e.g. JNJ Q4) during within-filing dedup
- Adds `tests/test_periods.py` boundary tests

Closes #1

## Test plan

- [x] `pytest` — all 66 tests pass (60 existing + 6 new)
- [x] No remaining references to `_is_quarterly` / `_is_annual_10k` / `_Q_DURATION_*` / `_A_DURATION_*`
- [x] Parser within-filing dedup behavior preserved (existing parser tests cover this)
- [x] Query Q4 derivation, TTM, and snapshot behavior preserved (existing query tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)