### PR TITLE
feat(parser): parse all us-gaap concepts by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-04-18
+
+### Changed
+- **Parser default now extracts every us-gaap concept**: `PitEdgarConfig.concepts` defaults to `None`, which causes `parse_company` / `parse_all` to iterate every `us-gaap:*` tag present in the per-company JSON instead of only the 15 in `DEFAULT_CONCEPTS`. Disk is cheap and parquet compresses well, so the broader output eliminates the need to re-parse the 1.5 GB cache when iterating on new quant signals. `CONCEPT_ALIASES` is still applied, so e.g. a filer reporting only `RevenueFromContractWithCustomerExcludingAssessedTax` still lands under `us-gaap:Revenues` in the parquet. **Migration**: rebuild the parquet with `pitedgar build --force` to populate the broader concept set; pass `concepts=DEFAULT_CONCEPTS` to keep the curated subset.
+
 ## [0.2.8] - 2026-04-18
 
 ### Added

--- a/pitedgar/config.py
+++ b/pitedgar/config.py
@@ -70,7 +70,12 @@ class PitEdgarConfig(BaseModel):
     data_dir: Path
     facts_dir: Path = None  # type: ignore[assignment]
     zip_url: str = BULK_ZIP_URL
-    concepts: list[str] = DEFAULT_CONCEPTS
+    # ``concepts`` controls which us-gaap tags are extracted from the per-company JSON.
+    # ``None`` (the default) or an empty list means "parse every us-gaap concept present
+    # in the JSON" — recommended so the parquet contains the full universe of tags and
+    # iterating on new signals does not require rebuilding the 1.5 GB cache. Pass an
+    # explicit list (e.g. ``DEFAULT_CONCEPTS``) to opt back into the curated subset.
+    concepts: list[str] | None = None
     forms: list[str] = DEFAULT_FORMS
 
     model_config = {"arbitrary_types_allowed": True}

--- a/pitedgar/parser.py
+++ b/pitedgar/parser.py
@@ -29,7 +29,7 @@ def _preferred_units(concept_short: str) -> list[str]:
 
 def parse_company(
     cik_padded: str,
-    concepts: list[str],
+    concepts: list[str] | None,
     facts_dir: Path,
     forms: list[str],
 ) -> pd.DataFrame:
@@ -37,12 +37,17 @@ def parse_company(
 
     Args:
         cik_padded: zero-padded 10-digit CIK string.
-        concepts:   list of "us-gaap:ConceptName" strings.
+        concepts:   list of "us-gaap:ConceptName" strings to extract. Pass ``None``
+                    or an empty list to extract every us-gaap concept present in
+                    the JSON (recommended — the full parquet supports flexible
+                    quant signal iteration without re-parsing the 1.5 GB cache).
         facts_dir:  directory containing CIK*.json files.
         forms:      filing forms to keep, e.g. ["10-K", "10-Q"].
 
     Returns:
-        DataFrame with columns: cik, concept, end, filed, val, form, accn
+        DataFrame with columns: cik, concept, end, filed, val, form, accn.
+        The ``concept`` column always contains the canonical full name
+        ``"us-gaap:<Name>"`` — alias tags are mapped to their canonical target.
     """
     json_path = facts_dir / f"CIK{cik_padded}.json"
     if not json_path.exists():
@@ -55,6 +60,18 @@ def parse_company(
     usgaap = data.get("facts", {}).get("us-gaap", {})
     if not usgaap:
         return pd.DataFrame()
+
+    # When ``concepts`` is None or empty, derive the canonical concept set from
+    # whatever us-gaap tags this company actually filed. Aliases are mapped to
+    # their canonical name so e.g. a filer that only reports the post-ASC 606
+    # revenue tag still ends up under ``us-gaap:Revenues`` in the parquet.
+    if not concepts:
+        canonical_set: set[str] = set()
+        for short_name in usgaap:
+            full_name = f"us-gaap:{short_name}"
+            canonical = CONCEPT_ALIASES.get(full_name, full_name)
+            canonical_set.add(canonical)
+        concepts = sorted(canonical_set)
 
     rows: list[dict] = []
 
@@ -85,6 +102,8 @@ def parse_company(
                 break
 
         if not unit_entries:
+            # Concept reported neither USD nor shares (e.g. pure/EUR/etc.) — skip
+            # silently to keep the parquet schema homogeneous.
             continue
 
         for entry in unit_entries:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pitedgar"
-version = "0.2.8"
+version = "0.2.9"
 description = "Point-in-time SEC EDGAR financial data pipeline"
 authors = ["Ariel Nacamulli"]
 license = "MIT"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,7 @@ import json
 import pandas as pd
 import pytest
 
-from pitedgar.config import PitEdgarConfig
+from pitedgar.config import DEFAULT_CONCEPTS, PitEdgarConfig
 from pitedgar.parser import parse_all, parse_company
 
 SAMPLE_FACTS = {
@@ -497,6 +497,214 @@ def test_parse_company_canonical_revenues_wins_over_sales_revenue_net(tmp_path):
 def test_parse_company_missing_file(tmp_path):
     df = parse_company("9999999999", ["us-gaap:Revenues"], tmp_path, ["10-K"])
     assert df.empty
+
+
+def test_parse_company_none_concepts_extracts_non_default_concept(tmp_path):
+    """concepts=None must pull in tags that are NOT part of the curated DEFAULT_CONCEPTS list."""
+    obscure_concept = "us-gaap:GoodwillImpairmentLoss"
+    assert obscure_concept not in DEFAULT_CONCEPTS  # guard against future curation changes
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "GoodwillImpairmentLoss": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 25_000_000,
+                                "form": "10-K",
+                                "accn": "G1",
+                            },
+                        ]
+                    }
+                },
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 800_000_000,
+                                "form": "10-K",
+                                "accn": "R1",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    cik = "0000000100"
+    (tmp_path / f"CIK{cik}.json").write_text(json.dumps(facts), encoding="utf-8")
+
+    df = parse_company(cik, None, tmp_path, ["10-K"])
+    assert obscure_concept in set(df["concept"])
+    assert "us-gaap:Revenues" in set(df["concept"])
+    goodwill_row = df[df["concept"] == obscure_concept].iloc[0]
+    assert goodwill_row["val"] == pytest.approx(25_000_000)
+
+
+def test_parse_company_empty_concepts_behaves_like_none(tmp_path):
+    """An empty concepts list must trigger the same "parse all" code path as None."""
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "AccruedLiabilitiesCurrent": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 50_000_000,
+                                "form": "10-K",
+                                "accn": "AL1",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    cik = "0000000101"
+    (tmp_path / f"CIK{cik}.json").write_text(json.dumps(facts), encoding="utf-8")
+
+    df = parse_company(cik, [], tmp_path, ["10-K"])
+    assert "us-gaap:AccruedLiabilitiesCurrent" in set(df["concept"])
+
+
+def test_parse_company_none_canonicalizes_aliases(tmp_path):
+    """When parsing all concepts, alias tags must still be stored under the canonical name."""
+    facts = {
+        "facts": {
+            "us-gaap": {
+                # Alias-only filer (post-ASC 606 revenue tag, no canonical Revenues)
+                "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2023-01-01",
+                                "end": "2023-12-31",
+                                "filed": "2024-02-01",
+                                "val": 600_000_000,
+                                "form": "10-K",
+                                "accn": "AL1",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    cik = "0000000102"
+    (tmp_path / f"CIK{cik}.json").write_text(json.dumps(facts), encoding="utf-8")
+
+    df = parse_company(cik, None, tmp_path, ["10-K"])
+    # Concept must appear as the canonical name, not the alias
+    assert set(df["concept"]) == {"us-gaap:Revenues"}
+    assert df.iloc[0]["val"] == pytest.approx(600_000_000)
+
+
+def test_parse_company_none_skips_unknown_non_usd_non_shares(tmp_path):
+    """Concepts reported only in foreign/exotic units must be silently skipped, not crash."""
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "SomeForeignCurrencyConcept": {
+                    "units": {
+                        "EUR": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 1_000_000,
+                                "form": "10-K",
+                                "accn": "F1",
+                            },
+                        ]
+                    }
+                },
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 800_000_000,
+                                "form": "10-K",
+                                "accn": "R1",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    cik = "0000000103"
+    (tmp_path / f"CIK{cik}.json").write_text(json.dumps(facts), encoding="utf-8")
+
+    df = parse_company(cik, None, tmp_path, ["10-K"])
+    # The EUR-only concept must NOT appear; Revenues must.
+    assert "us-gaap:SomeForeignCurrencyConcept" not in set(df["concept"])
+    assert "us-gaap:Revenues" in set(df["concept"])
+
+
+def test_parse_all_default_config_parses_all_concepts(tmp_path):
+    """A PitEdgarConfig with no explicit concepts should extract every us-gaap tag."""
+    cik = "0000320193"
+    facts_dir = tmp_path / "companyfacts"
+    facts_dir.mkdir()
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 1_000_000_000,
+                                "form": "10-K",
+                                "accn": "X1",
+                            },
+                        ]
+                    }
+                },
+                "GoodwillImpairmentLoss": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": "2022-01-01",
+                                "end": "2022-12-31",
+                                "filed": "2023-02-01",
+                                "val": 25_000_000,
+                                "form": "10-K",
+                                "accn": "X2",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+    (facts_dir / f"CIK{cik}.json").write_text(json.dumps(facts), encoding="utf-8")
+
+    config = PitEdgarConfig(
+        edgar_identity="Test test@example.com",
+        data_dir=tmp_path,
+        facts_dir=facts_dir,
+    )
+    # Sanity check: the new default is "parse everything"
+    assert config.concepts is None
+
+    master = parse_all(config, pd.DataFrame({"cik": [cik]}, index=pd.Index(["AAPL"], name="ticker")))
+    assert "us-gaap:GoodwillImpairmentLoss" in set(master["concept"])
+    assert "us-gaap:Revenues" in set(master["concept"])
 
 
 def test_parse_all(tmp_path):


### PR DESCRIPTION
## Summary
- `PitEdgarConfig.concepts` now defaults to `None`, which causes `parse_company` / `parse_all` to extract every `us-gaap:*` tag present in the per-company JSON instead of only the 15 in `DEFAULT_CONCEPTS`.
- Eliminates the need to re-parse the 1.5 GB cache when iterating on new quant signals — disk is cheap and parquet compresses well.
- `CONCEPT_ALIASES` is still applied: alias-only filers (e.g. only `RevenueFromContractWithCustomerExcludingAssessedTax`) still land under their canonical name (`us-gaap:Revenues`).
- Concepts that report neither USD nor shares are skipped silently to keep the parquet schema homogeneous.
- `DEFAULT_CONCEPTS` remains exported for users who want to opt back into the curated set.

## Migration
Rerun `pitedgar build --force` to populate the broader parquet. To keep the prior curated subset, pass `concepts=DEFAULT_CONCEPTS` when constructing `PitEdgarConfig`.

## Test plan
- [x] `pytest -x` — 89 tests pass (5 new parser tests added)
- [x] `ruff check .` — clean
- [x] `concepts=None` extracts non-`DEFAULT_CONCEPTS` tags (e.g. `GoodwillImpairmentLoss`)
- [x] `concepts=[]` triggers the same "parse all" path as `None`
- [x] Alias-only filers still canonicalize when parsing all
- [x] Foreign-currency-only concepts are skipped silently
- [x] Default `PitEdgarConfig` (concepts=None) round-trips through `parse_all`

https://claude.ai/code/session_01JdxwowqREyrEwvurAZeBK2