### PR TITLE
fix(query): derive missing 3-month rows from consecutive YTD disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`PitQuery.ttm()` / `ttm_cross_section()` inflated TTM for YTD-only filers**: companies that tag their quarterly disclosures only as year-to-date cumulative values (notably AAPL post-2021 for `us-gaap:NetIncomeLoss` / `us-gaap:Revenues` — Q1=90d, Q2=181d, Q3=272d, 10-K=363d, all sharing the same fiscal-year `start`) had no discrete 3-month rows for the TTM algorithm to sum. Result: `_ttm_events` fell back to summing the four most recent 90-day Q1 entries from consecutive fiscal years, producing a ~35% inflated TTM (AAPL TTM NetIncomeLoss at 2024-11-01 returned ~$127B instead of the published FY2024 figure of $93.7B). The query layer now synthesizes the missing 3-month rows from consecutive YTD records sharing the same `start`: `Q2_3m = YTD_6m − YTD_3m`, `Q3_3m = YTD_9m − YTD_6m`, `Q4_3m = FY − YTD_9m`. Synthetic rows are filed at `max(prev.filed, curr.filed)` (no look-ahead) and their `accn` is suffixed with `:DERIVED_YTD_DIFF` for audit. Explicit 3-month rows continue to take precedence over synthesized ones at the same `(end, filed)`, so filers with discrete quarterly tags (e.g. pre-2020 MSFT) see identical TTM output.
+
 ## [0.3.1] - 2026-04-20
 
 ### Fixed

--- a/pitedgar/parser.py
+++ b/pitedgar/parser.py
@@ -212,7 +212,7 @@ def parse_company(
 
 
 def _parse_one_for_pool(
-    args: tuple[str, str, list[str], Path, list[str]],
+    args: tuple[str, str, list[str] | None, Path, list[str]],
 ) -> tuple[str, pd.DataFrame]:
     """Top-level helper for ProcessPoolExecutor (must be picklable, hence not a closure).
 

--- a/pitedgar/query.py
+++ b/pitedgar/query.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from pitedgar.periods import is_annual, is_quarterly
+from pitedgar.periods import Q_MAX, Q_MIN, is_annual, is_quarterly
 
 
 def _snapshot_events(grp: pd.DataFrame) -> pd.DataFrame:
@@ -96,6 +96,110 @@ def _derive_q4_rows(df_q: pd.DataFrame, df_k: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows) if rows else pd.DataFrame(columns=["end", "filed", "val"])
 
 
+_SYNTH_COLS = ["end", "filed", "val", "duration_days", "form", "accn", "start"]
+
+
+def _derive_quarterly_from_ytd(df: pd.DataFrame) -> pd.DataFrame:
+    """Synthesize 3-month rows from consecutive YTD records sharing a `start`.
+
+    Some filers (notably AAPL post-2021 for NetIncomeLoss/Revenues) tag their
+    quarterly disclosures only as year-to-date cumulative values: Q1 is a 90-day
+    record, Q2 a 181-day record, Q3 a 272-day record, and the 10-K a 363-day
+    record — all sharing the same fiscal-year start. Without discrete 3-month
+    rows, ``_ttm_events`` has nothing to sum and ``ttm()`` falls back to summing
+    four Q1s from different years, producing an inflated TTM.
+
+    For each ``start`` group, this walks the sorted-by-end records and emits
+    a synthetic 3-month row for every consecutive YTD pair whose end-to-end
+    delta lands in the quarterly range:
+
+        Q2_3m = YTD_6m − YTD_3m     (quarters 181d, 90d → 91d synthetic)
+        Q3_3m = YTD_9m − YTD_6m     (quarters 272d, 181d → 91d synthetic)
+        Q4_3m = FY − YTD_9m         (quarters 363d, 272d → 91d synthetic)
+
+    Restatement handling: if either YTD end has multiple filings (different
+    `filed`/`val`), this emits one synthesized row per (prev_record, curr_record)
+    combination. The TTM state dict keyed by ``end`` absorbs duplicates at the
+    same (end, filed).
+
+    No look-ahead: synthesized `filed` = max(prev.filed, curr.filed), so the
+    row is only "known" after both YTD disclosures were filed.
+
+    Args:
+        df: rows for a single (ticker, concept). Must contain the columns
+            ``start``, ``end``, ``filed``, ``val``; ``form`` and ``accn`` are
+            used only for audit metadata on the emitted rows. Rows with a
+            missing ``start`` (e.g. balance-sheet instants) are ignored.
+
+    Returns DataFrame with columns: end, filed, val, duration_days, form,
+    accn, start. Empty when no YTD chain can be synthesized — including when
+    ``start`` is not present on the input.
+    """
+    empty = pd.DataFrame(columns=_SYNTH_COLS)
+    if df.empty or "start" not in df.columns:
+        return empty
+
+    ytd = df[df["start"].notna()]
+    if ytd.empty:
+        return empty
+
+    rows: list[dict] = []
+    for _, grp in ytd.groupby("start", sort=True):
+        ends = sorted(grp["end"].unique())
+        if len(ends) < 2:
+            continue
+        for i in range(1, len(ends)):
+            prev_end, curr_end = ends[i - 1], ends[i]
+            duration = (curr_end - prev_end).days
+            if duration < Q_MIN or duration > Q_MAX:
+                continue
+            prev_rows = grp[grp["end"] == prev_end]
+            curr_rows = grp[grp["end"] == curr_end]
+            for _, p in prev_rows.iterrows():
+                for _, c in curr_rows.iterrows():
+                    filed = p["filed"] if p["filed"] >= c["filed"] else c["filed"]
+                    src_accn = c.get("accn", "")
+                    src_form = c.get("form", "")
+                    rows.append(
+                        {
+                            "end": curr_end,
+                            "filed": filed,
+                            "val": c["val"] - p["val"],
+                            "duration_days": duration,
+                            "form": src_form,
+                            "accn": f"{src_accn}:DERIVED_YTD_DIFF",
+                            "start": prev_end,
+                        }
+                    )
+    return pd.DataFrame(rows, columns=_SYNTH_COLS) if rows else empty
+
+
+def _combine_quarterly_sources(
+    sub_all: pd.DataFrame,
+    quarterly_mask: pd.Series,
+) -> pd.DataFrame:
+    """Return the full 3-month row set for a (ticker, concept): explicit ∪ synthesized.
+
+    Explicit quarterly rows (those with ``is_quarterly(duration_days)``) take
+    precedence over synthesized ones at the same ``(end, filed)``. Returned
+    DataFrame has columns ``end, filed, val`` — the minimum needed by
+    ``_ttm_events`` and ``_derive_q4_rows``.
+    """
+    explicit = sub_all.loc[quarterly_mask]
+    synth = _derive_quarterly_from_ytd(sub_all)
+
+    if synth.empty:
+        return explicit[["end", "filed", "val"]].copy()
+
+    # Concat synthesized first, explicit second → drop_duplicates keep='last'
+    # so explicit wins when both are present for the same (end, filed).
+    synth_keep = synth[["end", "filed", "val"]]
+    explicit_keep = explicit[["end", "filed", "val"]]
+    combined = pd.concat([synth_keep, explicit_keep], ignore_index=True)
+    combined = combined.drop_duplicates(subset=["end", "filed"], keep="last")
+    return combined
+
+
 def _ttm_events(grp: pd.DataFrame, min_periods: int = 4) -> pd.DataFrame:
     """Compute TTM step-function events for one ticker from sorted 10-Q rows.
 
@@ -137,6 +241,10 @@ class PitQuery:
         self.data = pd.read_parquet(parquet_path)
         self.data["filed"] = pd.to_datetime(self.data["filed"], errors="coerce")
         self.data["end"] = pd.to_datetime(self.data["end"], errors="coerce")
+        # `start` is required by YTD-chain synthesis in ttm(); older fixtures and
+        # legacy parquets may lack it, in which case synthesis silently no-ops.
+        if "start" in self.data.columns:
+            self.data["start"] = pd.to_datetime(self.data["start"], errors="coerce")
         # Ensure duration_days exists for period classification. The parser always
         # writes this column; for test fixtures or legacy parquets without it,
         # infer from form (10-Q → 91, 10-K → 365) as a safe approximation.
@@ -297,11 +405,14 @@ class PitQuery:
         Returns DataFrame with columns: ticker, concept, filed, ttm_val, n_periods
         """
         base_mask = (self.data["ticker"] == ticker) & (self.data["concept"] == concept)
-        # Use duration_days to identify quarterly periods (60–105 days), regardless
-        # of form. Some companies (e.g. JNJ) report discrete quarterly values only
-        # inside 10-K filings as comparative data; form='10-Q' would miss them.
-        sub = self.data.loc[base_mask & is_quarterly(self.data["duration_days"])].sort_values("filed")
-        sub_k = self.data.loc[base_mask & is_annual(self.data["duration_days"], self.data["form"])]
+        sub_all = self.data.loc[base_mask]
+        sub_k = sub_all.loc[is_annual(sub_all["duration_days"], sub_all["form"])]
+
+        # Union explicit 3-month rows (duration_days 60–105, regardless of form —
+        # some companies like JNJ report quarterly breakdowns inside 10-K filings)
+        # with synthesized 3-month rows from consecutive YTD pairs (AAPL post-2021
+        # pattern: Q2/Q3 tagged only as YTD, no discrete 3-month disclosure).
+        sub = _combine_quarterly_sources(sub_all, is_quarterly(sub_all["duration_days"])).sort_values("filed")
 
         if sub.empty:
             return pd.DataFrame(columns=["ticker", "concept", "filed", "ttm_val", "n_periods"])
@@ -311,7 +422,7 @@ class PitQuery:
         # are not falsely nullified by the staleness check.
         q4_rows = _derive_q4_rows(sub, sub_k)
         if not q4_rows.empty:
-            sub = pd.concat([sub[["end", "filed", "val"]], q4_rows], ignore_index=True).sort_values("filed")
+            sub = pd.concat([sub, q4_rows], ignore_index=True).sort_values("filed")
 
         result = _ttm_events(sub, min_periods=min_periods)
         if result.empty:
@@ -387,31 +498,26 @@ class PitQuery:
         concept_mask = self.data["concept"] == concept
         if tickers is not None:
             concept_mask &= self.data["ticker"].isin(universe)
-        df_q = self.data.loc[concept_mask & is_quarterly(self.data["duration_days"])].sort_values(
-            ["ticker", "filed"]
-        )
-        df_k = self.data.loc[concept_mask & is_annual(self.data["duration_days"], self.data["form"])]
-
-        # Group 10-K rows by ticker for O(1) lookup inside the per-ticker loop.
-        k_by_ticker: dict = {}
-        if not df_k.empty:
-            for t, g in df_k.groupby("ticker", sort=False):
-                k_by_ticker[t] = g
+        df_all = self.data.loc[concept_mask].sort_values(["ticker", "filed"])
 
         # Compute TTM events for all tickers in one grouped pass.
-        # For tickers whose Q4 is only in the 10-K (e.g. December-FY companies),
-        # inject a synthetic Q4 = Annual − Q1 − Q2 − Q3 before running _ttm_events.
+        # Per ticker: build the unified 3-month row set (explicit ∪ YTD-synthesized),
+        # then inject a synthetic Q4 from 10-K when needed. The YTD step covers
+        # AAPL post-2021 (Q2/Q3 tagged only as YTD); the 10-K step covers December-FY
+        # companies whose Q4 never appears in a 10-Q.
         ttm_frames: list[pd.DataFrame] = []
         tickers_with_data: set = set()
-        for ticker, grp in df_q.groupby("ticker", sort=False):
-            grp_k = k_by_ticker.get(ticker, pd.DataFrame())
-            q4_rows = _derive_q4_rows(grp, grp_k)
+        q_mask = is_quarterly(df_all["duration_days"])
+        k_mask = is_annual(df_all["duration_days"], df_all["form"])
+        for ticker, grp_all in df_all.groupby("ticker", sort=False):
+            grp_q_mask = q_mask.loc[grp_all.index]
+            grp_k = grp_all.loc[k_mask.loc[grp_all.index]]
+            combined = _combine_quarterly_sources(grp_all, grp_q_mask).sort_values("filed")
+            if combined.empty:
+                continue
+            q4_rows = _derive_q4_rows(combined, grp_k)
             if not q4_rows.empty:
-                combined = pd.concat([grp[["end", "filed", "val"]], q4_rows], ignore_index=True).sort_values(
-                    "filed"
-                )
-            else:
-                combined = grp
+                combined = pd.concat([combined, q4_rows], ignore_index=True).sort_values("filed")
             events = _ttm_events(combined, min_periods=min_periods)
             if not events.empty:
                 events["ticker"] = ticker

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -889,7 +889,7 @@ def test_history_freq_q_picks_up_quarterly_data_from_10k(tmp_path):
     h = q.history("AAPL", CONCEPT, freq="Q")
     assert len(h) == 3
     assert set(h["form"]) == {"10-K"}
-    assert all((h["end"].dt.year == 2022))
+    assert all(h["end"].dt.year == 2022)
 
 
 def test_history_freq_a_returns_annual_and_freq_q_does_not(tmp_path):
@@ -981,3 +981,251 @@ def test_history_returns_latest_filed_per_end(tmp_path):
     assert len(h) == 2  # one row per period end
     q1 = h[h["end"] == pd.Timestamp("2023-03-31")].iloc[0]
     assert q1["val"] == pytest.approx(55.0)  # restated value, not 50.0
+
+
+# ---------------------------------------------------------------------------
+# YTD-chain synthesis (AAPL post-2021 pattern)
+# ---------------------------------------------------------------------------
+
+
+AAPL_FY24_NI = [
+    # AAPL FY2024 NetIncomeLoss, post-2021 tagging pattern: only YTD rows.
+    # Values (in USD) from the SEC filings; TTM after the 10-K should equal
+    # the published FY2024 net income of $93,736M.
+    ("2023-12-30", "2024-02-02", 33916000000.0, "10-Q", 90),  # Q1 FY24 YTD
+    ("2024-03-30", "2024-05-03", 57564000000.0, "10-Q", 181),  # Q2 FY24 YTD
+    ("2024-06-29", "2024-08-02", 79000000000.0, "10-Q", 272),  # Q3 FY24 YTD
+    ("2024-09-28", "2024-11-01", 93736000000.0, "10-K", 363),  # FY24 annual
+]
+
+AAPL_FY24_REV = [
+    ("2023-12-30", "2024-02-02", 119575000000.0, "10-Q", 90),
+    ("2024-03-30", "2024-05-03", 210328000000.0, "10-Q", 181),
+    ("2024-06-29", "2024-08-02", 296135000000.0, "10-Q", 272),
+    ("2024-09-28", "2024-11-01", 391035000000.0, "10-K", 363),
+]
+
+
+def _aapl_ytd_records(concept: str, entries: list[tuple], fy_start: str = "2023-10-01") -> list[dict]:
+    """Build YTD-only records for a ticker/concept mimicking AAPL post-2021 tagging."""
+    return [
+        {
+            "ticker": "AAPL",
+            "concept": concept,
+            "start": fy_start,
+            "end": end,
+            "filed": filed,
+            "val": val,
+            "form": form,
+            "accn": f"YTD{i}",
+            "duration_days": duration,
+        }
+        for i, (end, filed, val, form, duration) in enumerate(entries)
+    ]
+
+
+@pytest.fixture
+def aapl_ytd_parquet(tmp_path):
+    """AAPL FY2024 NetIncomeLoss + Revenues, post-2021 YTD-only tagging."""
+    records = _aapl_ytd_records("us-gaap:NetIncomeLoss", AAPL_FY24_NI) + _aapl_ytd_records(
+        "us-gaap:Revenues", AAPL_FY24_REV
+    )
+    df = pd.DataFrame(records)
+    path = tmp_path / "pit_financials.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_ttm_netincome_from_ytd_chain(aapl_ytd_parquet):
+    """AAPL FY2024 TTM NetIncomeLoss at 10-K date must equal FY value (~$93.7B)."""
+    q = PitQuery(aapl_ytd_parquet)
+    result = q.ttm("AAPL", "us-gaap:NetIncomeLoss")
+    last = result.iloc[-1]
+    # TTM = Q1_90d + (Q2_181d - Q1_90d) + (Q3_272d - Q2_181d) + (FY - Q3_272d) = FY.
+    assert last["ttm_val"] == pytest.approx(93736000000.0, rel=0.01)
+    assert last["n_periods"] == 4
+    assert last["filed"] == pd.Timestamp("2024-11-01")
+
+
+def test_ttm_revenues_from_ytd_chain(aapl_ytd_parquet):
+    """AAPL FY2024 TTM Revenues at 10-K date must equal FY value (~$391B)."""
+    q = PitQuery(aapl_ytd_parquet)
+    result = q.ttm("AAPL", "us-gaap:Revenues")
+    last = result.iloc[-1]
+    assert last["ttm_val"] == pytest.approx(391035000000.0, rel=0.01)
+
+
+def test_ttm_ytd_synthesis_no_lookahead(aapl_ytd_parquet):
+    """Synthetic quarters must not appear before both source YTDs are filed."""
+    q = PitQuery(aapl_ytd_parquet)
+    # Before Q2 YTD is filed (2024-05-03), only Q1_90d is known → no synth Q2_3m yet.
+    result = q.ttm("AAPL", "us-gaap:NetIncomeLoss", end_date="2024-04-30", min_periods=1)
+    # Only the 90d Q1 YTD is known → n_periods == 1 at the Q1 filing date.
+    assert not result.empty
+    assert (result["n_periods"] <= 1).all()
+
+
+def test_ttm_ytd_synthesis_after_two_ytds(aapl_ytd_parquet):
+    """After Q2 YTD is filed, synthetic Q2_3m appears → 2 periods available."""
+    q = PitQuery(aapl_ytd_parquet)
+    result = q.ttm("AAPL", "us-gaap:NetIncomeLoss", end_date="2024-05-03", min_periods=2)
+    last = result.iloc[-1]
+    # Q1_90d (33916) + synth Q2_3m (57564 − 33916 = 23648) = 57564.
+    assert last["ttm_val"] == pytest.approx(57564000000.0, rel=1e-6)
+    assert last["n_periods"] == 2
+
+
+def test_ttm_explicit_takes_precedence_over_synth(tmp_path):
+    """When both explicit 3-month and synthesized YTD-diff produce a row for the same
+    (end, filed), the explicit row wins (acceptance criterion)."""
+    records = [
+        # Discrete Q1 (90d)
+        {
+            "ticker": "X",
+            "concept": CONCEPT,
+            "start": "2024-01-01",
+            "end": "2024-03-31",
+            "filed": "2024-04-28",
+            "val": 100.0,
+            "form": "10-Q",
+            "accn": "Q1",
+            "duration_days": 91,
+        },
+        # Discrete Q2 (91d) — non-YTD, start at Q1 end. Value 200.
+        {
+            "ticker": "X",
+            "concept": CONCEPT,
+            "start": "2024-04-01",
+            "end": "2024-06-30",
+            "filed": "2024-07-28",
+            "val": 200.0,
+            "form": "10-Q",
+            "accn": "Q2_EXPLICIT",
+            "duration_days": 91,
+        },
+        # YTD_6m at same filed as explicit Q2 — creates a synth candidate at
+        # (end=2024-06-30, filed=2024-07-28) with val = 999 − 100 = 899.
+        {
+            "ticker": "X",
+            "concept": CONCEPT,
+            "start": "2024-01-01",
+            "end": "2024-06-30",
+            "filed": "2024-07-28",
+            "val": 999.0,
+            "form": "10-Q",
+            "accn": "YTD6",
+            "duration_days": 182,
+        },
+    ]
+    df = pd.DataFrame(records)
+    path = tmp_path / "pit_financials.parquet"
+    df.to_parquet(path, index=False)
+    q = PitQuery(path)
+    result = q.ttm("X", CONCEPT, min_periods=2)
+    last = result.iloc[-1]
+    # Explicit Q2 (200) must win, not synthesized (899). Expected TTM = 100 + 200 = 300.
+    assert last["ttm_val"] == pytest.approx(300.0)
+
+
+def test_ttm_no_regression_when_only_discrete_quarters(tmp_path):
+    """When a filer uses only discrete 3-month rows, YTD synthesis is a no-op and
+    TTM matches the pre-fix behavior."""
+    records = [
+        {
+            "ticker": "MSFT",
+            "concept": CONCEPT,
+            "start": "2019-07-01",
+            "end": "2019-09-30",
+            "filed": "2019-10-23",
+            "val": 100.0,
+            "form": "10-Q",
+            "accn": "D1",
+            "duration_days": 92,
+        },
+        {
+            "ticker": "MSFT",
+            "concept": CONCEPT,
+            "start": "2019-10-01",
+            "end": "2019-12-31",
+            "filed": "2020-01-29",
+            "val": 200.0,
+            "form": "10-Q",
+            "accn": "D2",
+            "duration_days": 92,
+        },
+        {
+            "ticker": "MSFT",
+            "concept": CONCEPT,
+            "start": "2020-01-01",
+            "end": "2020-03-31",
+            "filed": "2020-04-29",
+            "val": 300.0,
+            "form": "10-Q",
+            "accn": "D3",
+            "duration_days": 91,
+        },
+        {
+            "ticker": "MSFT",
+            "concept": CONCEPT,
+            "start": "2020-04-01",
+            "end": "2020-06-30",
+            "filed": "2020-07-22",
+            "val": 400.0,
+            "form": "10-Q",
+            "accn": "D4",
+            "duration_days": 91,
+        },
+    ]
+    df = pd.DataFrame(records)
+    path = tmp_path / "pit_financials.parquet"
+    df.to_parquet(path, index=False)
+    q = PitQuery(path)
+    result = q.ttm("MSFT", CONCEPT)
+    last = result.iloc[-1]
+    assert last["ttm_val"] == pytest.approx(1000.0)
+    assert last["n_periods"] == 4
+
+
+def test_ttm_cross_section_matches_ttm_on_ytd_universe(tmp_path):
+    """ttm_cross_section must return the same TTM as per-ticker ttm() for a mixed
+    universe — including AAPL-style YTD-only filers."""
+    records: list[dict] = []
+    # AAPL: YTD-only pattern (post-2021).
+    records.extend(_aapl_ytd_records("us-gaap:NetIncomeLoss", AAPL_FY24_NI))
+    # Four more tickers with discrete quarterly tagging.
+    fy_quarters = [
+        ("2023-03-31", "2023-04-28", 100.0, "10-Q", "2023-01-01"),
+        ("2023-06-30", "2023-07-28", 200.0, "10-Q", "2023-04-01"),
+        ("2023-09-30", "2023-10-28", 300.0, "10-Q", "2023-07-01"),
+        ("2023-12-31", "2024-02-02", 400.0, "10-Q", "2023-10-01"),
+    ]
+    for t in ("MSFT", "GOOG", "META", "NVDA"):
+        for i, (end, filed, val, form, start) in enumerate(fy_quarters):
+            records.append(
+                {
+                    "ticker": t,
+                    "concept": "us-gaap:NetIncomeLoss",
+                    "start": start,
+                    "end": end,
+                    "filed": filed,
+                    "val": val,
+                    "form": form,
+                    "accn": f"{t}{i}",
+                    "duration_days": 91,
+                }
+            )
+    df = pd.DataFrame(records)
+    path = tmp_path / "pit_financials.parquet"
+    df.to_parquet(path, index=False)
+    q = PitQuery(path)
+
+    universe = ["AAPL", "MSFT", "GOOG", "META", "NVDA"]
+    xs = q.ttm_cross_section("us-gaap:NetIncomeLoss", "2024-12-01", tickers=universe, max_staleness_days=365)
+    for t in universe:
+        solo = q.ttm("AAPL" if t == "AAPL" else t, "us-gaap:NetIncomeLoss")
+        expected = solo.iloc[-1]["ttm_val"] if not solo.empty else float("nan")
+        row = xs[xs["ticker"] == t].iloc[0]
+        if pd.isna(expected):
+            assert pd.isna(row["ttm_val"])
+        else:
+            assert row["ttm_val"] == pytest.approx(expected, rel=1e-6)


### PR DESCRIPTION
Closes #9.

## Summary

Fix inflated TTM for filers that tag quarterly disclosures only as YTD cumulative values. `PitQuery.ttm()` / `ttm_cross_section()` now synthesise the missing 3-month rows from consecutive YTD records sharing the same fiscal-year `start`:

```
Q2_3m = YTD_6m − YTD_3m
Q3_3m = YTD_9m − YTD_6m
Q4_3m = FY    − YTD_9m
```

- Synthesised `filed` = `max(prev.filed, curr.filed)` — no look-ahead.
- `accn` suffixed with `:DERIVED_YTD_DIFF` so synthetic rows are distinguishable in audit.
- Explicit 3-month rows take precedence over synthesised ones at the same `(end, filed)`, so discrete-quarter filers see identical output.

Before the fix, AAPL post-2021 `NetIncomeLoss` had no discrete Q2/Q3 rows, and `_ttm_events` fell back to summing four Q1s from consecutive fiscal years — inflating FY2024 TTM by ~35% ($127B observed vs $93.7B published).

## Test plan

- [x] 7 new unit tests: AAPL-pattern synthesis, PIT no-lookahead, explicit-wins dedup, no-regression for discrete-quarter filers, `ttm_cross_section` ↔ `ttm` parity on mixed universe.
- [x] Full suite: 122 passed.
- [x] End-to-end validation against real SEC data:
  - AAPL FY2024 TTM NI at 2024-11-01 = **$93.736B** (published $93.74B)
  - AAPL ROE at 2024-11-01 = **164.59%** (published 164.6%)
  - All four FY endings 2021–2024 match published figures to the dollar.
- [x] Both ingestion paths validated: bulk `companyfacts.zip` + per-company `data.sec.gov/api/xbrl/companyfacts/CIK{cik}.json` produce identical parquets (142 AAPL NI rows each, Δ=0 across every date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)